### PR TITLE
Add feature to select GPT models (#5)

### DIFF
--- a/autochat.ipynb
+++ b/autochat.ipynb
@@ -12,17 +12,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "driver = autochat.set_driver()\n",
-    "driver.get(\"https://chat.openai.com/chat\")\n",
-    "\n",
+    "driver.get(\"https://chat.openai.com/chat\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# login with openai account\n",
     "login.bypassing_cloudflare(driver)\n",
     "login.click_login_button(driver)\n",
+    "\n",
+    "# type your email and password\n",
     "login.login_openai(driver, email_address=\"your_email\", password=\"your_password\")\n",
     "# login.login_google_account(driver, email_address=\"your_email\", password=\"your_password\")\n",
+    "\n",
     "login.skip_start_message(driver)"
    ]
   },
@@ -32,6 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "autochat.set_gpt_model(driver, model=\"GPT-3.5-Legacy\") # GPT-3.5, GPT-3.5-Legacy, GPT-4\n",
     "autochat.send_prompt(driver, prompt=\"Hello, I am a bot. I am going to ask you some questions. Are you ready?\")"
    ]
   }

--- a/autochatgpt/autochat.py
+++ b/autochatgpt/autochat.py
@@ -22,6 +22,16 @@ def set_driver(headless=False):
     return driver
 
 
+def set_gpt_model(driver, model):
+    model_element_dic = {
+        "GPT-3.5": "//span[contains(text(), 'Default (GPT-3.5)')]",
+        "GPT-3.5-Legacy": "//span[contains(text(), 'Legacy (GPT-3.5)')]",
+        "GPT-4": "//span[contains(text(), 'GPT-4')]",
+    }
+    driver.find_element(By.XPATH, '//div[@class="relative w-full md:w-1/2 lg:w-1/3 xl:w-1/4"]//button').click()
+    driver.find_element(By.XPATH, model_element_dic.get(model)).click()
+
+
 def send_prompt(driver, prompt):
     textarea = driver.find_element(By.CSS_SELECTOR, "textarea")
     textarea.clear()
@@ -31,10 +41,16 @@ def send_prompt(driver, prompt):
 
 
 def get_user_prompt(driver):
-    user_elements = driver.find_elements(By.XPATH, '//div[contains(@class, "group w-full text-gray-800 dark:text-gray-100 border-b border-black/10 dark:border-gray-900/50 dark:bg-gray-800")]')
+    user_elements = driver.find_elements(
+        By.XPATH,
+        '//div[contains(@class, "group w-full text-gray-800 dark:text-gray-100 border-b border-black/10 dark:border-gray-900/50 dark:bg-gray-800")]',
+    )
     return [user_element.text for user_element in user_elements]
 
 
 def get_gpt_response(driver):
-    gpt_elements = driver.find_elements(By.XPATH, '//div[contains(@class, "group w-full text-gray-800 dark:text-gray-100 border-b border-black/10 dark:border-gray-900/50 bg-gray-50 dark:bg-[#444654]")]')
+    gpt_elements = driver.find_elements(
+        By.XPATH,
+        '//div[contains(@class, "group w-full text-gray-800 dark:text-gray-100 border-b border-black/10 dark:border-gray-900/50 bg-gray-50 dark:bg-[#444654]")]',
+    )
     return [gpt_element.text for gpt_element in gpt_elements]


### PR DESCRIPTION
Title: Add set_gpt_model function to allow GPT model selection

Description:

This pull request introduces a new feature that enables users to select the desired GPT model in the `autochat.py` script using the `set_gpt_model(driver, model)` function. The function takes two arguments: a Selenium WebDriver instance and the GPT model name. The available models are "GPT-3.5", "GPT-3.5-Legacy", and "GPT-4".

Changes:

1. Added a new function `set_gpt_model(driver, model)` in `autochat.py` that allows users to select the desired GPT model.
2. The `set_gpt_model` function uses Selenium to interact with the ChatGPT website and modify the GPT model accordingly.
3. Updated the `README.md` file to include instructions on how to use the new function and the list of available GPT models.