### PR TITLE
Add option to configure Chat History & Training in ChatGPT settings

### DIFF
--- a/autochat.ipynb
+++ b/autochat.ipynb
@@ -15,8 +15,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_chat = Chat(headless=False, wait=60)\n",
-    "new_chat.set_gpt_model(model=\"GPT-3.5\") # GPT-3.5, GPT-3.5-Legacy, GPT-4"
+    "new_chat = Chat(headless=False, wait=10)\n",
+    "new_chat.set_gpt_model(model=\"GPT-3.5\") # GPT-3.5, GPT-3.5-Legacy, GPT-4\n",
+    "new_chat.set_chat_history_and_training(check=\"False\") # true or false"
    ]
   },
   {

--- a/autochatgpt/autochat.py
+++ b/autochatgpt/autochat.py
@@ -33,6 +33,20 @@ class Chat:
         driver.implicitly_wait(wait_time)
         return driver
 
+    def set_chat_history_and_training(self, check):
+        # Open Data Controls settings window
+        self.driver.find_element(By.XPATH, '//div[@class="group relative" and @data-headlessui-state=""]').click()
+        self.driver.find_element(By.XPATH, '//a[contains(text(),"Settings")]').click()
+        self.driver.find_element(By.XPATH, '//button[contains(., "Data controls")]').click()
+
+        checked_value = self.driver.find_element(By.XPATH, "//button[@aria-checked]").get_attribute("aria-checked")
+        if checked_value != check:
+            # click Chat History and Training Button
+            self.driver.find_element(By.XPATH, '//button[contains(@id, "headlessui-switch-")]').click()
+
+        # close settings window
+        self.driver.find_element(By.XPATH, '//div[@class="sm:mt-0"]/button').click()
+
     def get_driver(self):
         return self.driver
 


### PR DESCRIPTION
This PR adds a new feature that allows users to configure the Chat History & Training settings in ChatGPT. Users can now enable or disable this option according to their preference, providing more control over their privacy and data usage.