### PR TITLE
Refactor module and class names for clarity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,6 @@
   "python.linting.mypyEnabled": true,
   "python.linting.mypyPath": "${workspaceFolder}/.venv/bin/mypy",
   "python.testing.pytestEnabled": true,
-  "autoDocstring.docstringFormat": "google"
+  "autoDocstring.docstringFormat": "google",
+  "cSpell.words": ["autochat"]
 }

--- a/autochat copy.ipynb
+++ b/autochat copy.ipynb
@@ -37,7 +37,7 @@
     {
      "data": {
       "text/plain": [
-       "['Yes, I am ready to answer your questions.']"
+       "[\"Hello, as an AI language model, I'm always ready to answer your questions. Please feel free to ask whatever you like.\"]"
       ]
      },
      "execution_count": 4,

--- a/autochatgpt/chat_gpt_bot.py
+++ b/autochatgpt/chat_gpt_bot.py
@@ -13,12 +13,12 @@ from autochatgpt import login
 # from selenium.webdriver.support.ui import WebDriverWait
 
 
-class Chat:
+class ChatGPTBot:
     OPENAI_URL = "https://chat.openai.com/chat"
 
     def __init__(self, headless=True, wait=60):
         self.driver = self.set_driver(headless, wait)
-        self.driver.get(Chat.OPENAI_URL)
+        self.driver.get(ChatGPTBot.OPENAI_URL)
         self.login()
 
     def set_driver(self, headless, wait_time):
@@ -90,4 +90,4 @@ class Chat:
         return [gpt_element.text for gpt_element in gpt_elements]
 
     def resume_chat(self, chatid):
-        self.driver.get(Chat.OPENAI_URL + f"/c/{chatid}")
+        self.driver.get(ChatGPTBot.OPENAI_URL + f"/c/{chatid}")


### PR DESCRIPTION
- Rename autochat.py to chat_gpt_bot.py to better reflect the purpose of the module
- Rename Chat class to ChatGPTBot for consistency with the new module name

These changes improve the naming convention of the codebase, making it clearer and easier to understand.