### PR TITLE
Fix GPT model selection method (#21)

### DIFF
--- a/autochatgpt/chatgptbot.py
+++ b/autochatgpt/chatgptbot.py
@@ -65,14 +65,10 @@ class ChatGPTBot:
             raise ValueError("ACCOUNT_TYPE must be OPENAI or GOOGLE")
         login.skip_start_message(self.driver)
 
-    def set_gpt_model(self, model):
-        model_element_dic = {
-            "GPT-3.5": "//span[contains(text(), 'Default (GPT-3.5)')]",
-            "GPT-3.5-Legacy": "//span[contains(text(), 'Legacy (GPT-3.5)')]",
-            "GPT-4": "//span[contains(text(), 'GPT-4')]",
-        }
-        self.driver.find_element(By.XPATH, '//div[@class="relative w-full md:w-1/2 lg:w-1/3 xl:w-1/4"]//button').click()
-        self.driver.find_element(By.XPATH, model_element_dic.get(model)).click()
+    def set_gpt_model(self, model_version):
+        if model_version not in ["GPT-3.5", "GPT-4"]:
+            raise ValueError("model_version must be GPT-3.5 or GPT-4")
+        self.driver.find_element(By.XPATH, f"//button[contains(., '{model_version}')]").click()
 
     def send_prompt(self, prompt):
         textarea = self.driver.find_element(By.CSS_SELECTOR, "textarea")

--- a/examples/autochat.ipynb
+++ b/examples/autochat.ipynb
@@ -16,7 +16,8 @@
    "outputs": [],
    "source": [
     "new_chat = ChatGPTBot(headless=False, wait=10)\n",
-    "# new_chat.set_gpt_model(model=\"GPT-3.5\") # GPT-3.5, GPT-4\n",
+    "\n",
+    "# new_chat.set_gpt_model(model_version=\"GPT-4\")  # This function is valid only for ChatGPT PLUS. model_version must be GPT-3.5 or GPT-4\n",
     "# new_chat.set_chat_history_and_training(check=\"False\") # true or false"
    ]
   },
@@ -37,7 +38,7 @@
     {
      "data": {
       "text/plain": [
-       "[\"Yes, I'm ready to answer your questions. Please go ahead.\"]"
+       "[\"Hello! I'm an AI language model here to help answer your questions. Please go ahead and ask me anything you'd like to know, and I'll do my best to assist you.\"]"
       ]
      },
      "execution_count": 4,


### PR DESCRIPTION
Changed the method of selecting a GPT model in the set_gpt_model function. Previously, this was achieved using a dropdown menu, but this method has been discontinued as of May 13, 2023. The updated implementation uses a simple button selection. This change simplifies the process and improves usability.