### PR TITLE
Fix set_chat_history_and_training and Support new conversation

### DIFF
--- a/autochatgpt/autobot.py
+++ b/autochatgpt/autobot.py
@@ -75,7 +75,10 @@ class AutoBot:
             self.driver.find_element(By.XPATH, '//button[contains(@role, "switch")]').click()
 
         # close settings window
-        self.driver.find_element(By.XPATH, '//button[contains(@class, "inline-block")]').click()
+        self.driver.find_element(
+            By.XPATH,
+            "//button[@class='text-gray-500 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200']",
+        ).click()
 
     def get_driver(self) -> uc.Chrome:
         """Get driver.

--- a/autochatgpt/autobot.py
+++ b/autochatgpt/autobot.py
@@ -5,7 +5,7 @@ import time
 
 import undetected_chromedriver as uc
 from dotenv import load_dotenv
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -182,6 +182,13 @@ class AutoBot:
             '//div[contains(@class, "markdown")]',
         )
         return [gpt_element.text for gpt_element in gpt_elements]
+
+    def new_conversation(self) -> None:
+        """Create new conversation."""
+        try:
+            self.driver.find_element(By.LINK_TEXT, "New chat").click()
+        except ElementClickInterceptedException:
+            self.driver.find_element(By.LINK_TEXT, "Clear chat").click()
 
     def resume_conversation(self, chatid: str) -> None:
         """Resume conversation.

--- a/examples/autochat.ipynb
+++ b/examples/autochat.ipynb
@@ -17,6 +17,7 @@
    "source": [
     "new_chat = autochatgpt.AutoBot(headless=False, wait=10)\n",
     "new_chat.auto_login()\n",
+    "new_chat.set_chat_history_and_training(check=False)\n",
     "# new_chat.set_gpt_model(model_version=\"GPT-4\")  # This function is valid only for ChatGPT PLUS. model_version must be GPT-3.5 or GPT-4"
    ]
   },

--- a/tests/test_autobot.py
+++ b/tests/test_autobot.py
@@ -5,6 +5,7 @@ def test_autobot():
     # Test ChatGPTBot class
     bot = AutoBot(headless=True, wait=10)
     bot.auto_login()
+    bot.set_chat_history_and_training(check=False)
     bot.set_gpt_model(model_version="GPT-3.5")
     bot.send_prompt(prompt="Hello, world!")
     # user_prompt = bot.get_user_prompt()


### PR DESCRIPTION
## Background
This MR addresses various enhancements and bug fixes in the auto-chat functionality of the `auto-chatgpt` repository.

## Changes

### [Fix for set_chat_history_and_training](https://github.com/ryuseisan/auto-chatgpt/pull/35/commits/961ab7406d07a784e7a84f85158997aac5c5eb8d)

- Modified the `set_chat_history_and_training` method to accommodate updated elements on web pages in `autochatgpt/autobot.py`.
- Added the updated method in `examples/autochat.ipynb`.
- Added tests for the modified method in `tests/test_autobot.py`.

### [Support for Creating New Conversations -> click "+ New chat" button](https://github.com/ryuseisan/auto-chatgpt/pull/35/commits/d070d0897ab3b45073b58c9e88d77ed421745230)

- Added a new method to create fresh conversations in `autochatgpt/autobot.py`.

## Impacts
These changes significantly enhance the auto-chat feature by addressing issues and adding new capabilities. The modified methods and added functionalities improve the overall user experience.