### PR TITLE
Add bypassing Cloudflare Turnstile function

### DIFF
--- a/autochatgpt/autobot.py
+++ b/autochatgpt/autobot.py
@@ -5,7 +5,7 @@ import time
 
 import undetected_chromedriver as uc
 from dotenv import load_dotenv
-from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
+from selenium.common.exceptions import ElementClickInterceptedException, NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -107,7 +107,10 @@ class AutoBot:
         Raises:
             ValueError: AUTO_CHATGPT_ACCOUNT_TYPE must be OPENAI or GOOGLE
         """
-        # login.bypassing_cloudflare(driver)
+        try:
+            login.bypassing_cloudflare(self.driver)
+        except NoSuchElementException:
+            pass  # If there is no Cloudflare Turnstile, skip it
         login.click_login_button(self.driver)
 
         if account_type == "OPENAI":


### PR DESCRIPTION
## Background
This MR addresses the reimplementation of the bypassing Cloudflare Turnstile function in the `auto-chatgpt` repository.

## Changes

### [Addition of Cloudflare Turnstile Bypass](https://github.com/ryuseisan/auto-chatgpt/pull/36/commits/c3651b3bcc6c7ae932483589bcd3fa0494ba0dc9)
- `autochatgpt/autobot.py`
  - Restored the previously commented-out method for bypassing Cloudflare.
  - The method is now reinstated to handle cases where Cloudflare Turnstile is not displayed, allowing for seamless operation.

## Impacts
The reintroduction of the Cloudflare Turnstile bypass method significantly improves the stability and reliability of the auto-chat functionality. This enhancement ensures that the process runs smoothly even in scenarios where Cloudflare Turnstile is absent.